### PR TITLE
Update updater endpoint / Release 1.8.0

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -90,7 +90,7 @@ if ( version_compare( PHP_VERSION, '5.3.29' ) >= 0 ) {
 mm_require( MM_BASE_DIR . 'inc/admin-page-notifications-blocker.php' );
 
 // Set up the updater endpoint and map values
-$mojo_update_url     = 'https://hiive.cloud/workers/release-api/plugins/bluehost/mojo-marketplace-wp-plugin?file=mojo-marketplace.php'; // Custom API GET endpoint
+$mojo_update_url     = 'https://hiive.cloud/workers/release-api/plugins/newfold-labs/wp-plugin-mojo?slug=mojo-marketplace-wp-plugin&file=mojo-marketplace.php '; // Custom API GET endpoint
 $mojo_plugin_updater = new PluginUpdater( MM_FILE, $mojo_update_url );
 $mojo_plugin_updater->setDataMap(
 	array(

--- a/mojo-marketplace.php
+++ b/mojo-marketplace.php
@@ -11,8 +11,8 @@
  * Plugin Name:       The MOJO Marketplace
  * Plugin URI:        https://mojomarketplace.com
  * Description:       This plugin adds shortcodes, widgets, and themes to your WordPress site.
- * Version:           1.7.9
- * Tested up to:      6.3.2
+ * Version:           1.8.0
+ * Tested up to:      6.6.1
  * Requires at least: 5.8
  * Requires PHP:      5.6
  * Author:            Bluehost
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'MM_VERSION', '1.7.9' );
+define( 'MM_VERSION', '1.8.0' );
 define( 'MM_FILE', __FILE__ );
 define( 'MM_BASE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MM_BASE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
This marks the point that plugins will look to the new endpoint for updates. The plugin will then self-update to the new version of the plugin. 

Must be coordinated with https://github.com/newfold-labs/wp-plugin-mojo/pull/290

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
